### PR TITLE
Upgrade to 0.12.0 and move away from boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,8 @@ find_package (OpenSSL REQUIRED)
 #if (NOT THRIFT_FOUND)
 	ExternalProject_Add(
 	  LibThrift
-	  GIT_REPOSITORY "https://github.com/phrocker/thrift.git"
-	  GIT_TAG 8c4b75db00aa8f7f5fca44d14296a45030683dd8
+	  GIT_REPOSITORY "https://github.com/apache/thrift.git"
+	  GIT_TAG "v0.12.0"
 	  BUILD_IN_SOURCE true
 	  SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/dependencies/thrift-src"
 	  CMAKE_ARGS "-DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/thrift"
@@ -53,6 +53,7 @@ find_package (OpenSSL REQUIRED)
 	  			 "-DWITH_JAVA=OFF"
 	  			 "-DWITH_LIBEVENT=ON"
 	  			 "-DWITH_PYTHON=OFF"
+	  			 "-DOPENSSL_ROOT_DIR=${LIBRESSL_BIN_DIR}"
 	  			 "-DWITH_HASKELL=OFF"
 	  			 "-DWITH_SHARED_LIB=OFF"
 	  			 "-DWITH_C_GLIB=OFF"

--- a/include/data/extern/boost/SharedPointer.h
+++ b/include/data/extern/boost/SharedPointer.h
@@ -52,15 +52,5 @@ template<class T> std::shared_ptr<T> from_shared_ptr(const std::shared_ptr<T> &p
   return p;
 }
 
-/*
- template<class T> boost::shared_ptr<T> from_shared_ptr(const std::shared_ptr<T> &p) {
- typedef Replacement<boost::shared_ptr<T>> H;
- if (H * h = std::get_deleter < H > (p)) {
- return h->p;
- } else {
- return boost::shared_ptr < T > (p.get(), Replacement<std::shared_ptr<T>>(p));
- }
- }*/
-
 }
 }

--- a/include/data/extern/boost/SharedPointer.h
+++ b/include/data/extern/boost/SharedPointer.h
@@ -12,7 +12,6 @@
  * limitations under the License.
  */
 
-
 #pragma once
 
 #include <memory>
@@ -42,21 +41,26 @@ template<class PtrConvert> struct Replacement {
 
 template<class T> std::shared_ptr<T> to_shared_ptr(const boost::shared_ptr<T> &p) {
   typedef Replacement<std::shared_ptr<T>> H;
-  if (H *h = boost::get_deleter < H > (p)) {
+  if (H *h = boost::get_deleter<H>(p)) {
     return h->p;
   } else {
-    return std::shared_ptr < T > (p.get(), Replacement<boost::shared_ptr<T>>(p));
+    return std::shared_ptr<T>(p.get(), Replacement<boost::shared_ptr<T>>(p));
   }
 }
 
-template<class T> boost::shared_ptr<T> from_shared_ptr(const std::shared_ptr<T> &p) {
-  typedef Replacement<boost::shared_ptr<T>> H;
-  if (H * h = std::get_deleter < H > (p)) {
-    return h->p;
-  } else {
-    return boost::shared_ptr < T > (p.get(), Replacement<std::shared_ptr<T>>(p));
-  }
+template<class T> std::shared_ptr<T> from_shared_ptr(const std::shared_ptr<T> &p) {
+  return p;
 }
+
+/*
+ template<class T> boost::shared_ptr<T> from_shared_ptr(const std::shared_ptr<T> &p) {
+ typedef Replacement<boost::shared_ptr<T>> H;
+ if (H * h = std::get_deleter < H > (p)) {
+ return h->p;
+ } else {
+ return boost::shared_ptr < T > (p.get(), Replacement<std::shared_ptr<T>>(p));
+ }
+ }*/
 
 }
 }

--- a/include/data/extern/thrift/ClientService.h
+++ b/include/data/extern/thrift/ClientService.h
@@ -65,7 +65,7 @@ class ClientServiceIfFactory {
 
 class ClientServiceIfSingletonFactory : virtual public ClientServiceIfFactory {
  public:
-  ClientServiceIfSingletonFactory(const boost::shared_ptr<ClientServiceIf>& iface) : iface_(iface) {}
+  ClientServiceIfSingletonFactory(const std::shared_ptr<ClientServiceIf>& iface) : iface_(iface) {}
   virtual ~ClientServiceIfSingletonFactory() {}
 
   virtual ClientServiceIf* getHandler(const ::apache::thrift::TConnectionInfo&) {
@@ -74,7 +74,7 @@ class ClientServiceIfSingletonFactory : virtual public ClientServiceIfFactory {
   virtual void releaseHandler(ClientServiceIf* /* handler */) {}
 
  protected:
-  boost::shared_ptr<ClientServiceIf> iface_;
+  std::shared_ptr<ClientServiceIf> iface_;
 };
 
 class ClientServiceNull : virtual public ClientServiceIf {
@@ -3976,27 +3976,27 @@ class ClientService_checkNamespaceClass_presult {
 
 class ClientServiceClient : virtual public ClientServiceIf {
  public:
-  ClientServiceClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
+  ClientServiceClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
     setProtocol(prot);
   }
-  ClientServiceClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
+  ClientServiceClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
     setProtocol(iprot,oprot);
   }
  private:
-  void setProtocol(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
+  void setProtocol(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
   setProtocol(prot,prot);
   }
-  void setProtocol(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
+  void setProtocol(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
     piprot_=iprot;
     poprot_=oprot;
     iprot_ = iprot.get();
     oprot_ = oprot.get();
   }
  public:
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
     return piprot_;
   }
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
     return poprot_;
   }
   void getRootTabletLocation(std::string& _return);
@@ -4090,15 +4090,15 @@ class ClientServiceClient : virtual public ClientServiceIf {
   void send_checkNamespaceClass(const  ::org::apache::accumulo::core::trace::thrift::TInfo& tinfo, const  ::org::apache::accumulo::core::security::thrift::TCredentials& credentials, const std::string& namespaceId, const std::string& className, const std::string& interfaceMatch);
   bool recv_checkNamespaceClass();
  protected:
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot_;
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot_;
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot_;
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot_;
   ::apache::thrift::protocol::TProtocol* iprot_;
   ::apache::thrift::protocol::TProtocol* oprot_;
 };
 
 class ClientServiceProcessor : public ::apache::thrift::TDispatchProcessor {
  protected:
-  boost::shared_ptr<ClientServiceIf> iface_;
+  std::shared_ptr<ClientServiceIf> iface_;
   virtual bool dispatchCall(::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, const std::string& fname, int32_t seqid, void* callContext);
  private:
   typedef  void (ClientServiceProcessor::*ProcessFunction)(int32_t, ::apache::thrift::protocol::TProtocol*, ::apache::thrift::protocol::TProtocol*, void*);
@@ -4135,7 +4135,7 @@ class ClientServiceProcessor : public ::apache::thrift::TDispatchProcessor {
   void process_checkTableClass(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
   void process_checkNamespaceClass(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
  public:
-  ClientServiceProcessor(boost::shared_ptr<ClientServiceIf> iface) :
+  ClientServiceProcessor(std::shared_ptr<ClientServiceIf> iface) :
     iface_(iface) {
     processMap_["getRootTabletLocation"] = &ClientServiceProcessor::process_getRootTabletLocation;
     processMap_["getInstanceId"] = &ClientServiceProcessor::process_getInstanceId;
@@ -4174,24 +4174,24 @@ class ClientServiceProcessor : public ::apache::thrift::TDispatchProcessor {
 
 class ClientServiceProcessorFactory : public ::apache::thrift::TProcessorFactory {
  public:
-  ClientServiceProcessorFactory(const ::boost::shared_ptr< ClientServiceIfFactory >& handlerFactory) :
+  ClientServiceProcessorFactory(const ::std::shared_ptr< ClientServiceIfFactory >& handlerFactory) :
       handlerFactory_(handlerFactory) {}
 
-  ::boost::shared_ptr< ::apache::thrift::TProcessor > getProcessor(const ::apache::thrift::TConnectionInfo& connInfo);
+  ::std::shared_ptr< ::apache::thrift::TProcessor > getProcessor(const ::apache::thrift::TConnectionInfo& connInfo);
 
  protected:
-  ::boost::shared_ptr< ClientServiceIfFactory > handlerFactory_;
+  ::std::shared_ptr< ClientServiceIfFactory > handlerFactory_;
 };
 
 class ClientServiceMultiface : virtual public ClientServiceIf {
  public:
-  ClientServiceMultiface(std::vector<boost::shared_ptr<ClientServiceIf> >& ifaces) : ifaces_(ifaces) {
+  ClientServiceMultiface(std::vector<std::shared_ptr<ClientServiceIf> >& ifaces) : ifaces_(ifaces) {
   }
   virtual ~ClientServiceMultiface() {}
  protected:
-  std::vector<boost::shared_ptr<ClientServiceIf> > ifaces_;
+  std::vector<std::shared_ptr<ClientServiceIf> > ifaces_;
   ClientServiceMultiface() {}
-  void add(boost::shared_ptr<ClientServiceIf> iface) {
+  void add(std::shared_ptr<ClientServiceIf> iface) {
     ifaces_.push_back(iface);
   }
  public:
@@ -4482,27 +4482,27 @@ class ClientServiceMultiface : virtual public ClientServiceIf {
 // only be used when you need to share a connection among multiple threads
 class ClientServiceConcurrentClient : virtual public ClientServiceIf {
  public:
-  ClientServiceConcurrentClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
+  ClientServiceConcurrentClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
     setProtocol(prot);
   }
-  ClientServiceConcurrentClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
+  ClientServiceConcurrentClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
     setProtocol(iprot,oprot);
   }
  private:
-  void setProtocol(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
+  void setProtocol(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
   setProtocol(prot,prot);
   }
-  void setProtocol(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
+  void setProtocol(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
     piprot_=iprot;
     poprot_=oprot;
     iprot_ = iprot.get();
     oprot_ = oprot.get();
   }
  public:
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
     return piprot_;
   }
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
     return poprot_;
   }
   void getRootTabletLocation(std::string& _return);
@@ -4596,8 +4596,8 @@ class ClientServiceConcurrentClient : virtual public ClientServiceIf {
   int32_t send_checkNamespaceClass(const  ::org::apache::accumulo::core::trace::thrift::TInfo& tinfo, const  ::org::apache::accumulo::core::security::thrift::TCredentials& credentials, const std::string& namespaceId, const std::string& className, const std::string& interfaceMatch);
   bool recv_checkNamespaceClass(const int32_t seqid);
  protected:
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot_;
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot_;
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot_;
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot_;
   ::apache::thrift::protocol::TProtocol* iprot_;
   ::apache::thrift::protocol::TProtocol* oprot_;
   ::apache::thrift::async::TConcurrentClientSyncInfo sync_;

--- a/include/data/extern/thrift/FateService.h
+++ b/include/data/extern/thrift/FateService.h
@@ -39,7 +39,7 @@ class FateServiceIfFactory {
 
 class FateServiceIfSingletonFactory : virtual public FateServiceIfFactory {
  public:
-  FateServiceIfSingletonFactory(const boost::shared_ptr<FateServiceIf>& iface) : iface_(iface) {}
+  FateServiceIfSingletonFactory(const std::shared_ptr<FateServiceIf>& iface) : iface_(iface) {}
   virtual ~FateServiceIfSingletonFactory() {}
 
   virtual FateServiceIf* getHandler(const ::apache::thrift::TConnectionInfo&) {
@@ -48,7 +48,7 @@ class FateServiceIfSingletonFactory : virtual public FateServiceIfFactory {
   virtual void releaseHandler(FateServiceIf* /* handler */) {}
 
  protected:
-  boost::shared_ptr<FateServiceIf> iface_;
+  std::shared_ptr<FateServiceIf> iface_;
 };
 
 class FateServiceNull : virtual public FateServiceIf {
@@ -596,27 +596,27 @@ class FateService_finishFateOperation_presult {
 
 class FateServiceClient : virtual public FateServiceIf {
  public:
-  FateServiceClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
+  FateServiceClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
     setProtocol(prot);
   }
-  FateServiceClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
+  FateServiceClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
     setProtocol(iprot,oprot);
   }
  private:
-  void setProtocol(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
+  void setProtocol(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
   setProtocol(prot,prot);
   }
-  void setProtocol(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
+  void setProtocol(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
     piprot_=iprot;
     poprot_=oprot;
     iprot_ = iprot.get();
     oprot_ = oprot.get();
   }
  public:
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
     return piprot_;
   }
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
     return poprot_;
   }
   int64_t beginFateOperation(const  ::org::apache::accumulo::core::trace::thrift::TInfo& tinfo, const  ::org::apache::accumulo::core::security::thrift::TCredentials& credentials);
@@ -632,15 +632,15 @@ class FateServiceClient : virtual public FateServiceIf {
   void send_finishFateOperation(const  ::org::apache::accumulo::core::trace::thrift::TInfo& tinfo, const  ::org::apache::accumulo::core::security::thrift::TCredentials& credentials, const int64_t opid);
   void recv_finishFateOperation();
  protected:
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot_;
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot_;
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot_;
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot_;
   ::apache::thrift::protocol::TProtocol* iprot_;
   ::apache::thrift::protocol::TProtocol* oprot_;
 };
 
 class FateServiceProcessor : public ::apache::thrift::TDispatchProcessor {
  protected:
-  boost::shared_ptr<FateServiceIf> iface_;
+  std::shared_ptr<FateServiceIf> iface_;
   virtual bool dispatchCall(::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, const std::string& fname, int32_t seqid, void* callContext);
  private:
   typedef  void (FateServiceProcessor::*ProcessFunction)(int32_t, ::apache::thrift::protocol::TProtocol*, ::apache::thrift::protocol::TProtocol*, void*);
@@ -651,7 +651,7 @@ class FateServiceProcessor : public ::apache::thrift::TDispatchProcessor {
   void process_waitForFateOperation(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
   void process_finishFateOperation(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
  public:
-  FateServiceProcessor(boost::shared_ptr<FateServiceIf> iface) :
+  FateServiceProcessor(std::shared_ptr<FateServiceIf> iface) :
     iface_(iface) {
     processMap_["beginFateOperation"] = &FateServiceProcessor::process_beginFateOperation;
     processMap_["executeFateOperation"] = &FateServiceProcessor::process_executeFateOperation;
@@ -664,24 +664,24 @@ class FateServiceProcessor : public ::apache::thrift::TDispatchProcessor {
 
 class FateServiceProcessorFactory : public ::apache::thrift::TProcessorFactory {
  public:
-  FateServiceProcessorFactory(const ::boost::shared_ptr< FateServiceIfFactory >& handlerFactory) :
+  FateServiceProcessorFactory(const ::std::shared_ptr< FateServiceIfFactory >& handlerFactory) :
       handlerFactory_(handlerFactory) {}
 
-  ::boost::shared_ptr< ::apache::thrift::TProcessor > getProcessor(const ::apache::thrift::TConnectionInfo& connInfo);
+  ::std::shared_ptr< ::apache::thrift::TProcessor > getProcessor(const ::apache::thrift::TConnectionInfo& connInfo);
 
  protected:
-  ::boost::shared_ptr< FateServiceIfFactory > handlerFactory_;
+  ::std::shared_ptr< FateServiceIfFactory > handlerFactory_;
 };
 
 class FateServiceMultiface : virtual public FateServiceIf {
  public:
-  FateServiceMultiface(std::vector<boost::shared_ptr<FateServiceIf> >& ifaces) : ifaces_(ifaces) {
+  FateServiceMultiface(std::vector<std::shared_ptr<FateServiceIf> >& ifaces) : ifaces_(ifaces) {
   }
   virtual ~FateServiceMultiface() {}
  protected:
-  std::vector<boost::shared_ptr<FateServiceIf> > ifaces_;
+  std::vector<std::shared_ptr<FateServiceIf> > ifaces_;
   FateServiceMultiface() {}
-  void add(boost::shared_ptr<FateServiceIf> iface) {
+  void add(std::shared_ptr<FateServiceIf> iface) {
     ifaces_.push_back(iface);
   }
  public:
@@ -729,27 +729,27 @@ class FateServiceMultiface : virtual public FateServiceIf {
 // only be used when you need to share a connection among multiple threads
 class FateServiceConcurrentClient : virtual public FateServiceIf {
  public:
-  FateServiceConcurrentClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
+  FateServiceConcurrentClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
     setProtocol(prot);
   }
-  FateServiceConcurrentClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
+  FateServiceConcurrentClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
     setProtocol(iprot,oprot);
   }
  private:
-  void setProtocol(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
+  void setProtocol(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
   setProtocol(prot,prot);
   }
-  void setProtocol(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
+  void setProtocol(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
     piprot_=iprot;
     poprot_=oprot;
     iprot_ = iprot.get();
     oprot_ = oprot.get();
   }
  public:
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
     return piprot_;
   }
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
     return poprot_;
   }
   int64_t beginFateOperation(const  ::org::apache::accumulo::core::trace::thrift::TInfo& tinfo, const  ::org::apache::accumulo::core::security::thrift::TCredentials& credentials);
@@ -765,8 +765,8 @@ class FateServiceConcurrentClient : virtual public FateServiceIf {
   int32_t send_finishFateOperation(const  ::org::apache::accumulo::core::trace::thrift::TInfo& tinfo, const  ::org::apache::accumulo::core::security::thrift::TCredentials& credentials, const int64_t opid);
   void recv_finishFateOperation(const int32_t seqid);
  protected:
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot_;
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot_;
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot_;
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot_;
   ::apache::thrift::protocol::TProtocol* iprot_;
   ::apache::thrift::protocol::TProtocol* oprot_;
   ::apache::thrift::async::TConcurrentClientSyncInfo sync_;

--- a/include/data/extern/thrift/GCMonitorService.h
+++ b/include/data/extern/thrift/GCMonitorService.h
@@ -30,7 +30,7 @@ class GCMonitorServiceIfFactory {
 
 class GCMonitorServiceIfSingletonFactory : virtual public GCMonitorServiceIfFactory {
  public:
-  GCMonitorServiceIfSingletonFactory(const boost::shared_ptr<GCMonitorServiceIf>& iface) : iface_(iface) {}
+  GCMonitorServiceIfSingletonFactory(const std::shared_ptr<GCMonitorServiceIf>& iface) : iface_(iface) {}
   virtual ~GCMonitorServiceIfSingletonFactory() {}
 
   virtual GCMonitorServiceIf* getHandler(const ::apache::thrift::TConnectionInfo&) {
@@ -39,7 +39,7 @@ class GCMonitorServiceIfSingletonFactory : virtual public GCMonitorServiceIfFact
   virtual void releaseHandler(GCMonitorServiceIf* /* handler */) {}
 
  protected:
-  boost::shared_ptr<GCMonitorServiceIf> iface_;
+  std::shared_ptr<GCMonitorServiceIf> iface_;
 };
 
 class GCMonitorServiceNull : virtual public GCMonitorServiceIf {
@@ -187,42 +187,42 @@ class GCMonitorService_getStatus_presult {
 
 class GCMonitorServiceClient : virtual public GCMonitorServiceIf {
  public:
-  GCMonitorServiceClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
+  GCMonitorServiceClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
     setProtocol(prot);
   }
-  GCMonitorServiceClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
+  GCMonitorServiceClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
     setProtocol(iprot,oprot);
   }
  private:
-  void setProtocol(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
+  void setProtocol(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
   setProtocol(prot,prot);
   }
-  void setProtocol(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
+  void setProtocol(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
     piprot_=iprot;
     poprot_=oprot;
     iprot_ = iprot.get();
     oprot_ = oprot.get();
   }
  public:
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
     return piprot_;
   }
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
     return poprot_;
   }
   void getStatus(GCStatus& _return, const  ::org::apache::accumulo::core::trace::thrift::TInfo& tinfo, const  ::org::apache::accumulo::core::security::thrift::TCredentials& credentials);
   void send_getStatus(const  ::org::apache::accumulo::core::trace::thrift::TInfo& tinfo, const  ::org::apache::accumulo::core::security::thrift::TCredentials& credentials);
   void recv_getStatus(GCStatus& _return);
  protected:
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot_;
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot_;
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot_;
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot_;
   ::apache::thrift::protocol::TProtocol* iprot_;
   ::apache::thrift::protocol::TProtocol* oprot_;
 };
 
 class GCMonitorServiceProcessor : public ::apache::thrift::TDispatchProcessor {
  protected:
-  boost::shared_ptr<GCMonitorServiceIf> iface_;
+  std::shared_ptr<GCMonitorServiceIf> iface_;
   virtual bool dispatchCall(::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, const std::string& fname, int32_t seqid, void* callContext);
  private:
   typedef  void (GCMonitorServiceProcessor::*ProcessFunction)(int32_t, ::apache::thrift::protocol::TProtocol*, ::apache::thrift::protocol::TProtocol*, void*);
@@ -230,7 +230,7 @@ class GCMonitorServiceProcessor : public ::apache::thrift::TDispatchProcessor {
   ProcessMap processMap_;
   void process_getStatus(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
  public:
-  GCMonitorServiceProcessor(boost::shared_ptr<GCMonitorServiceIf> iface) :
+  GCMonitorServiceProcessor(std::shared_ptr<GCMonitorServiceIf> iface) :
     iface_(iface) {
     processMap_["getStatus"] = &GCMonitorServiceProcessor::process_getStatus;
   }
@@ -240,24 +240,24 @@ class GCMonitorServiceProcessor : public ::apache::thrift::TDispatchProcessor {
 
 class GCMonitorServiceProcessorFactory : public ::apache::thrift::TProcessorFactory {
  public:
-  GCMonitorServiceProcessorFactory(const ::boost::shared_ptr< GCMonitorServiceIfFactory >& handlerFactory) :
+  GCMonitorServiceProcessorFactory(const ::std::shared_ptr< GCMonitorServiceIfFactory >& handlerFactory) :
       handlerFactory_(handlerFactory) {}
 
-  ::boost::shared_ptr< ::apache::thrift::TProcessor > getProcessor(const ::apache::thrift::TConnectionInfo& connInfo);
+  ::std::shared_ptr< ::apache::thrift::TProcessor > getProcessor(const ::apache::thrift::TConnectionInfo& connInfo);
 
  protected:
-  ::boost::shared_ptr< GCMonitorServiceIfFactory > handlerFactory_;
+  ::std::shared_ptr< GCMonitorServiceIfFactory > handlerFactory_;
 };
 
 class GCMonitorServiceMultiface : virtual public GCMonitorServiceIf {
  public:
-  GCMonitorServiceMultiface(std::vector<boost::shared_ptr<GCMonitorServiceIf> >& ifaces) : ifaces_(ifaces) {
+  GCMonitorServiceMultiface(std::vector<std::shared_ptr<GCMonitorServiceIf> >& ifaces) : ifaces_(ifaces) {
   }
   virtual ~GCMonitorServiceMultiface() {}
  protected:
-  std::vector<boost::shared_ptr<GCMonitorServiceIf> > ifaces_;
+  std::vector<std::shared_ptr<GCMonitorServiceIf> > ifaces_;
   GCMonitorServiceMultiface() {}
-  void add(boost::shared_ptr<GCMonitorServiceIf> iface) {
+  void add(std::shared_ptr<GCMonitorServiceIf> iface) {
     ifaces_.push_back(iface);
   }
  public:

--- a/include/data/extern/thrift/MasterClientService.h
+++ b/include/data/extern/thrift/MasterClientService.h
@@ -54,7 +54,7 @@ class MasterClientServiceIfFactory : virtual public FateServiceIfFactory {
 
 class MasterClientServiceIfSingletonFactory : virtual public MasterClientServiceIfFactory {
  public:
-  MasterClientServiceIfSingletonFactory(const boost::shared_ptr<MasterClientServiceIf>& iface) : iface_(iface) {}
+  MasterClientServiceIfSingletonFactory(const std::shared_ptr<MasterClientServiceIf>& iface) : iface_(iface) {}
   virtual ~MasterClientServiceIfSingletonFactory() {}
 
   virtual MasterClientServiceIf* getHandler(const ::apache::thrift::TConnectionInfo&) {
@@ -63,7 +63,7 @@ class MasterClientServiceIfSingletonFactory : virtual public MasterClientService
   virtual void releaseHandler(FateServiceIf* /* handler */) {}
 
  protected:
-  boost::shared_ptr<MasterClientServiceIf> iface_;
+  std::shared_ptr<MasterClientServiceIf> iface_;
 };
 
 class MasterClientServiceNull : virtual public MasterClientServiceIf , virtual public FateServiceNull {
@@ -2289,13 +2289,13 @@ class MasterClientService_drainReplicationTable_presult {
 
 class MasterClientServiceClient : virtual public MasterClientServiceIf, public FateServiceClient {
  public:
-  MasterClientServiceClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) :
+  MasterClientServiceClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) :
     FateServiceClient(prot, prot) {}
-  MasterClientServiceClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) :    FateServiceClient(iprot, oprot) {}
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
+  MasterClientServiceClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) :    FateServiceClient(iprot, oprot) {}
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
     return piprot_;
   }
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
     return poprot_;
   }
   int64_t initiateFlush(const  ::org::apache::accumulo::core::trace::thrift::TInfo& tinfo, const  ::org::apache::accumulo::core::security::thrift::TCredentials& credentials, const std::string& tableName);
@@ -2354,7 +2354,7 @@ class MasterClientServiceClient : virtual public MasterClientServiceIf, public F
 
 class MasterClientServiceProcessor : public FateServiceProcessor {
  protected:
-  boost::shared_ptr<MasterClientServiceIf> iface_;
+  std::shared_ptr<MasterClientServiceIf> iface_;
   virtual bool dispatchCall(::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, const std::string& fname, int32_t seqid, void* callContext);
  private:
   typedef  void (MasterClientServiceProcessor::*ProcessFunction)(int32_t, ::apache::thrift::protocol::TProtocol*, ::apache::thrift::protocol::TProtocol*, void*);
@@ -2379,7 +2379,7 @@ class MasterClientServiceProcessor : public FateServiceProcessor {
   void process_getDelegationToken(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
   void process_drainReplicationTable(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
  public:
-  MasterClientServiceProcessor(boost::shared_ptr<MasterClientServiceIf> iface) :
+  MasterClientServiceProcessor(std::shared_ptr<MasterClientServiceIf> iface) :
     FateServiceProcessor(iface),
     iface_(iface) {
     processMap_["initiateFlush"] = &MasterClientServiceProcessor::process_initiateFlush;
@@ -2407,28 +2407,28 @@ class MasterClientServiceProcessor : public FateServiceProcessor {
 
 class MasterClientServiceProcessorFactory : public ::apache::thrift::TProcessorFactory {
  public:
-  MasterClientServiceProcessorFactory(const ::boost::shared_ptr< MasterClientServiceIfFactory >& handlerFactory) :
+  MasterClientServiceProcessorFactory(const ::std::shared_ptr< MasterClientServiceIfFactory >& handlerFactory) :
       handlerFactory_(handlerFactory) {}
 
-  ::boost::shared_ptr< ::apache::thrift::TProcessor > getProcessor(const ::apache::thrift::TConnectionInfo& connInfo);
+  ::std::shared_ptr< ::apache::thrift::TProcessor > getProcessor(const ::apache::thrift::TConnectionInfo& connInfo);
 
  protected:
-  ::boost::shared_ptr< MasterClientServiceIfFactory > handlerFactory_;
+  ::std::shared_ptr< MasterClientServiceIfFactory > handlerFactory_;
 };
 
 class MasterClientServiceMultiface : virtual public MasterClientServiceIf, public FateServiceMultiface {
  public:
-  MasterClientServiceMultiface(std::vector<boost::shared_ptr<MasterClientServiceIf> >& ifaces) : ifaces_(ifaces) {
-    std::vector<boost::shared_ptr<MasterClientServiceIf> >::iterator iter;
+  MasterClientServiceMultiface(std::vector<std::shared_ptr<MasterClientServiceIf> >& ifaces) : ifaces_(ifaces) {
+    std::vector<std::shared_ptr<MasterClientServiceIf> >::iterator iter;
     for (iter = ifaces.begin(); iter != ifaces.end(); ++iter) {
       FateServiceMultiface::add(*iter);
     }
   }
   virtual ~MasterClientServiceMultiface() {}
  protected:
-  std::vector<boost::shared_ptr<MasterClientServiceIf> > ifaces_;
+  std::vector<std::shared_ptr<MasterClientServiceIf> > ifaces_;
   MasterClientServiceMultiface() {}
-  void add(boost::shared_ptr<MasterClientServiceIf> iface) {
+  void add(std::shared_ptr<MasterClientServiceIf> iface) {
     FateServiceMultiface::add(iface);
     ifaces_.push_back(iface);
   }
@@ -2605,13 +2605,13 @@ class MasterClientServiceMultiface : virtual public MasterClientServiceIf, publi
 // only be used when you need to share a connection among multiple threads
 class MasterClientServiceConcurrentClient : virtual public MasterClientServiceIf, public FateServiceConcurrentClient {
  public:
-  MasterClientServiceConcurrentClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) :
+  MasterClientServiceConcurrentClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) :
     FateServiceConcurrentClient(prot, prot) {}
-  MasterClientServiceConcurrentClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) :    FateServiceConcurrentClient(iprot, oprot) {}
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
+  MasterClientServiceConcurrentClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) :    FateServiceConcurrentClient(iprot, oprot) {}
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
     return piprot_;
   }
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
     return poprot_;
   }
   int64_t initiateFlush(const  ::org::apache::accumulo::core::trace::thrift::TInfo& tinfo, const  ::org::apache::accumulo::core::security::thrift::TCredentials& credentials, const std::string& tableName);

--- a/include/data/extern/thrift/SpanReceiver.h
+++ b/include/data/extern/thrift/SpanReceiver.h
@@ -36,7 +36,7 @@ class SpanReceiverIfFactory {
 
 class SpanReceiverIfSingletonFactory : virtual public SpanReceiverIfFactory {
  public:
-  SpanReceiverIfSingletonFactory(const boost::shared_ptr<SpanReceiverIf>& iface) : iface_(iface) {}
+  SpanReceiverIfSingletonFactory(const std::shared_ptr<SpanReceiverIf>& iface) : iface_(iface) {}
   virtual ~SpanReceiverIfSingletonFactory() {}
 
   virtual SpanReceiverIf* getHandler(const ::apache::thrift::TConnectionInfo&) {
@@ -45,7 +45,7 @@ class SpanReceiverIfSingletonFactory : virtual public SpanReceiverIfFactory {
   virtual void releaseHandler(SpanReceiverIf* /* handler */) {}
 
  protected:
-  boost::shared_ptr<SpanReceiverIf> iface_;
+  std::shared_ptr<SpanReceiverIf> iface_;
 };
 
 class SpanReceiverNull : virtual public SpanReceiverIf {
@@ -107,41 +107,41 @@ class SpanReceiver_span_pargs {
 
 class SpanReceiverClient : virtual public SpanReceiverIf {
  public:
-  SpanReceiverClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
+  SpanReceiverClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
     setProtocol(prot);
   }
-  SpanReceiverClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
+  SpanReceiverClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
     setProtocol(iprot,oprot);
   }
  private:
-  void setProtocol(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
+  void setProtocol(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
   setProtocol(prot,prot);
   }
-  void setProtocol(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
+  void setProtocol(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
     piprot_=iprot;
     poprot_=oprot;
     iprot_ = iprot.get();
     oprot_ = oprot.get();
   }
  public:
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
     return piprot_;
   }
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
     return poprot_;
   }
   void span(const RemoteSpan& span);
   void send_span(const RemoteSpan& span);
  protected:
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot_;
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot_;
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot_;
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot_;
   ::apache::thrift::protocol::TProtocol* iprot_;
   ::apache::thrift::protocol::TProtocol* oprot_;
 };
 
 class SpanReceiverProcessor : public ::apache::thrift::TDispatchProcessor {
  protected:
-  boost::shared_ptr<SpanReceiverIf> iface_;
+  std::shared_ptr<SpanReceiverIf> iface_;
   virtual bool dispatchCall(::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, const std::string& fname, int32_t seqid, void* callContext);
  private:
   typedef  void (SpanReceiverProcessor::*ProcessFunction)(int32_t, ::apache::thrift::protocol::TProtocol*, ::apache::thrift::protocol::TProtocol*, void*);
@@ -149,7 +149,7 @@ class SpanReceiverProcessor : public ::apache::thrift::TDispatchProcessor {
   ProcessMap processMap_;
   void process_span(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
  public:
-  SpanReceiverProcessor(boost::shared_ptr<SpanReceiverIf> iface) :
+  SpanReceiverProcessor(std::shared_ptr<SpanReceiverIf> iface) :
     iface_(iface) {
     processMap_["span"] = &SpanReceiverProcessor::process_span;
   }
@@ -159,24 +159,24 @@ class SpanReceiverProcessor : public ::apache::thrift::TDispatchProcessor {
 
 class SpanReceiverProcessorFactory : public ::apache::thrift::TProcessorFactory {
  public:
-  SpanReceiverProcessorFactory(const ::boost::shared_ptr< SpanReceiverIfFactory >& handlerFactory) :
+  SpanReceiverProcessorFactory(const ::std::shared_ptr< SpanReceiverIfFactory >& handlerFactory) :
       handlerFactory_(handlerFactory) {}
 
-  ::boost::shared_ptr< ::apache::thrift::TProcessor > getProcessor(const ::apache::thrift::TConnectionInfo& connInfo);
+  ::std::shared_ptr< ::apache::thrift::TProcessor > getProcessor(const ::apache::thrift::TConnectionInfo& connInfo);
 
  protected:
-  ::boost::shared_ptr< SpanReceiverIfFactory > handlerFactory_;
+  ::std::shared_ptr< SpanReceiverIfFactory > handlerFactory_;
 };
 
 class SpanReceiverMultiface : virtual public SpanReceiverIf {
  public:
-  SpanReceiverMultiface(std::vector<boost::shared_ptr<SpanReceiverIf> >& ifaces) : ifaces_(ifaces) {
+  SpanReceiverMultiface(std::vector<std::shared_ptr<SpanReceiverIf> >& ifaces) : ifaces_(ifaces) {
   }
   virtual ~SpanReceiverMultiface() {}
  protected:
-  std::vector<boost::shared_ptr<SpanReceiverIf> > ifaces_;
+  std::vector<std::shared_ptr<SpanReceiverIf> > ifaces_;
   SpanReceiverMultiface() {}
-  void add(boost::shared_ptr<SpanReceiverIf> iface) {
+  void add(std::shared_ptr<SpanReceiverIf> iface) {
     ifaces_.push_back(iface);
   }
  public:
@@ -196,34 +196,34 @@ class SpanReceiverMultiface : virtual public SpanReceiverIf {
 // only be used when you need to share a connection among multiple threads
 class SpanReceiverConcurrentClient : virtual public SpanReceiverIf {
  public:
-  SpanReceiverConcurrentClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
+  SpanReceiverConcurrentClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
     setProtocol(prot);
   }
-  SpanReceiverConcurrentClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
+  SpanReceiverConcurrentClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
     setProtocol(iprot,oprot);
   }
  private:
-  void setProtocol(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
+  void setProtocol(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
   setProtocol(prot,prot);
   }
-  void setProtocol(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
+  void setProtocol(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
     piprot_=iprot;
     poprot_=oprot;
     iprot_ = iprot.get();
     oprot_ = oprot.get();
   }
  public:
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
     return piprot_;
   }
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
     return poprot_;
   }
   void span(const RemoteSpan& span);
   void send_span(const RemoteSpan& span);
  protected:
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot_;
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot_;
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot_;
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot_;
   ::apache::thrift::protocol::TProtocol* iprot_;
   ::apache::thrift::protocol::TProtocol* oprot_;
   ::apache::thrift::async::TConcurrentClientSyncInfo sync_;

--- a/include/data/extern/thrift/TabletClientService.h
+++ b/include/data/extern/thrift/TabletClientService.h
@@ -67,7 +67,7 @@ class TabletClientServiceIfFactory : virtual public  ::org::apache::accumulo::co
 
 class TabletClientServiceIfSingletonFactory : virtual public TabletClientServiceIfFactory {
  public:
-  TabletClientServiceIfSingletonFactory(const boost::shared_ptr<TabletClientServiceIf>& iface) : iface_(iface) {}
+  TabletClientServiceIfSingletonFactory(const std::shared_ptr<TabletClientServiceIf>& iface) : iface_(iface) {}
   virtual ~TabletClientServiceIfSingletonFactory() {}
 
   virtual TabletClientServiceIf* getHandler(const ::apache::thrift::TConnectionInfo&) {
@@ -76,7 +76,7 @@ class TabletClientServiceIfSingletonFactory : virtual public TabletClientService
   virtual void releaseHandler( ::org::apache::accumulo::core::client::impl::thrift::ClientServiceIf* /* handler */) {}
 
  protected:
-  boost::shared_ptr<TabletClientServiceIf> iface_;
+  std::shared_ptr<TabletClientServiceIf> iface_;
 };
 
 class TabletClientServiceNull : virtual public TabletClientServiceIf , virtual public  ::org::apache::accumulo::core::client::impl::thrift::ClientServiceNull {
@@ -3537,13 +3537,13 @@ class TabletClientService_getActiveLogs_presult {
 
 class TabletClientServiceClient : virtual public TabletClientServiceIf, public  ::org::apache::accumulo::core::client::impl::thrift::ClientServiceClient {
  public:
-  TabletClientServiceClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) :
+  TabletClientServiceClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) :
      ::org::apache::accumulo::core::client::impl::thrift::ClientServiceClient(prot, prot) {}
-  TabletClientServiceClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) :     ::org::apache::accumulo::core::client::impl::thrift::ClientServiceClient(iprot, oprot) {}
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
+  TabletClientServiceClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) :     ::org::apache::accumulo::core::client::impl::thrift::ClientServiceClient(iprot, oprot) {}
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
     return piprot_;
   }
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
     return poprot_;
   }
   void startScan( ::org::apache::accumulo::core::data::thrift::InitialScan& _return, const  ::org::apache::accumulo::core::trace::thrift::TInfo& tinfo, const  ::org::apache::accumulo::core::security::thrift::TCredentials& credentials, const  ::org::apache::accumulo::core::data::thrift::TKeyExtent& extent, const  ::org::apache::accumulo::core::data::thrift::TRange& range, const std::vector< ::org::apache::accumulo::core::data::thrift::TColumn> & columns, const int32_t batchSize, const std::vector< ::org::apache::accumulo::core::data::thrift::IterInfo> & ssiList, const std::map<std::string, std::map<std::string, std::string> > & ssio, const std::vector<std::string> & authorizations, const bool waitForWrites, const bool isolated, const int64_t readaheadThreshold);
@@ -3632,7 +3632,7 @@ class TabletClientServiceClient : virtual public TabletClientServiceIf, public  
 
 class TabletClientServiceProcessor : public  ::org::apache::accumulo::core::client::impl::thrift::ClientServiceProcessor {
  protected:
-  boost::shared_ptr<TabletClientServiceIf> iface_;
+  std::shared_ptr<TabletClientServiceIf> iface_;
   virtual bool dispatchCall(::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, const std::string& fname, int32_t seqid, void* callContext);
  private:
   typedef  void (TabletClientServiceProcessor::*ProcessFunction)(int32_t, ::apache::thrift::protocol::TProtocol*, ::apache::thrift::protocol::TProtocol*, void*);
@@ -3670,7 +3670,7 @@ class TabletClientServiceProcessor : public  ::org::apache::accumulo::core::clie
   void process_removeLogs(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
   void process_getActiveLogs(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
  public:
-  TabletClientServiceProcessor(boost::shared_ptr<TabletClientServiceIf> iface) :
+  TabletClientServiceProcessor(std::shared_ptr<TabletClientServiceIf> iface) :
      ::org::apache::accumulo::core::client::impl::thrift::ClientServiceProcessor(iface),
     iface_(iface) {
     processMap_["startScan"] = &TabletClientServiceProcessor::process_startScan;
@@ -3711,28 +3711,28 @@ class TabletClientServiceProcessor : public  ::org::apache::accumulo::core::clie
 
 class TabletClientServiceProcessorFactory : public ::apache::thrift::TProcessorFactory {
  public:
-  TabletClientServiceProcessorFactory(const ::boost::shared_ptr< TabletClientServiceIfFactory >& handlerFactory) :
+  TabletClientServiceProcessorFactory(const ::std::shared_ptr< TabletClientServiceIfFactory >& handlerFactory) :
       handlerFactory_(handlerFactory) {}
 
-  ::boost::shared_ptr< ::apache::thrift::TProcessor > getProcessor(const ::apache::thrift::TConnectionInfo& connInfo);
+  ::std::shared_ptr< ::apache::thrift::TProcessor > getProcessor(const ::apache::thrift::TConnectionInfo& connInfo);
 
  protected:
-  ::boost::shared_ptr< TabletClientServiceIfFactory > handlerFactory_;
+  ::std::shared_ptr< TabletClientServiceIfFactory > handlerFactory_;
 };
 
 class TabletClientServiceMultiface : virtual public TabletClientServiceIf, public  ::org::apache::accumulo::core::client::impl::thrift::ClientServiceMultiface {
  public:
-  TabletClientServiceMultiface(std::vector<boost::shared_ptr<TabletClientServiceIf> >& ifaces) : ifaces_(ifaces) {
-    std::vector<boost::shared_ptr<TabletClientServiceIf> >::iterator iter;
+  TabletClientServiceMultiface(std::vector<std::shared_ptr<TabletClientServiceIf> >& ifaces) : ifaces_(ifaces) {
+    std::vector<std::shared_ptr<TabletClientServiceIf> >::iterator iter;
     for (iter = ifaces.begin(); iter != ifaces.end(); ++iter) {
        ::org::apache::accumulo::core::client::impl::thrift::ClientServiceMultiface::add(*iter);
     }
   }
   virtual ~TabletClientServiceMultiface() {}
  protected:
-  std::vector<boost::shared_ptr<TabletClientServiceIf> > ifaces_;
+  std::vector<std::shared_ptr<TabletClientServiceIf> > ifaces_;
   TabletClientServiceMultiface() {}
-  void add(boost::shared_ptr<TabletClientServiceIf> iface) {
+  void add(std::shared_ptr<TabletClientServiceIf> iface) {
      ::org::apache::accumulo::core::client::impl::thrift::ClientServiceMultiface::add(iface);
     ifaces_.push_back(iface);
   }
@@ -4037,13 +4037,13 @@ class TabletClientServiceMultiface : virtual public TabletClientServiceIf, publi
 // only be used when you need to share a connection among multiple threads
 class TabletClientServiceConcurrentClient : virtual public TabletClientServiceIf, public  ::org::apache::accumulo::core::client::impl::thrift::ClientServiceConcurrentClient {
  public:
-  TabletClientServiceConcurrentClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) :
+  TabletClientServiceConcurrentClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) :
      ::org::apache::accumulo::core::client::impl::thrift::ClientServiceConcurrentClient(prot, prot) {}
-  TabletClientServiceConcurrentClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) :     ::org::apache::accumulo::core::client::impl::thrift::ClientServiceConcurrentClient(iprot, oprot) {}
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
+  TabletClientServiceConcurrentClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) :     ::org::apache::accumulo::core::client::impl::thrift::ClientServiceConcurrentClient(iprot, oprot) {}
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
     return piprot_;
   }
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
     return poprot_;
   }
   void startScan( ::org::apache::accumulo::core::data::thrift::InitialScan& _return, const  ::org::apache::accumulo::core::trace::thrift::TInfo& tinfo, const  ::org::apache::accumulo::core::security::thrift::TCredentials& credentials, const  ::org::apache::accumulo::core::data::thrift::TKeyExtent& extent, const  ::org::apache::accumulo::core::data::thrift::TRange& range, const std::vector< ::org::apache::accumulo::core::data::thrift::TColumn> & columns, const int32_t batchSize, const std::vector< ::org::apache::accumulo::core::data::thrift::IterInfo> & ssiList, const std::map<std::string, std::map<std::string, std::string> > & ssio, const std::vector<std::string> & authorizations, const bool waitForWrites, const bool isolated, const int64_t readaheadThreshold);

--- a/include/data/extern/thrift/TestService.h
+++ b/include/data/extern/thrift/TestService.h
@@ -30,7 +30,7 @@ class TestServiceIfFactory {
 
 class TestServiceIfSingletonFactory : virtual public TestServiceIfFactory {
  public:
-  TestServiceIfSingletonFactory(const boost::shared_ptr<TestServiceIf>& iface) : iface_(iface) {}
+  TestServiceIfSingletonFactory(const std::shared_ptr<TestServiceIf>& iface) : iface_(iface) {}
   virtual ~TestServiceIfSingletonFactory() {}
 
   virtual TestServiceIf* getHandler(const ::apache::thrift::TConnectionInfo&) {
@@ -39,7 +39,7 @@ class TestServiceIfSingletonFactory : virtual public TestServiceIfFactory {
   virtual void releaseHandler(TestServiceIf* /* handler */) {}
 
  protected:
-  boost::shared_ptr<TestServiceIf> iface_;
+  std::shared_ptr<TestServiceIf> iface_;
 };
 
 class TestServiceNull : virtual public TestServiceIf {
@@ -180,42 +180,42 @@ class TestService_checkTrace_presult {
 
 class TestServiceClient : virtual public TestServiceIf {
  public:
-  TestServiceClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
+  TestServiceClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
     setProtocol(prot);
   }
-  TestServiceClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
+  TestServiceClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
     setProtocol(iprot,oprot);
   }
  private:
-  void setProtocol(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
+  void setProtocol(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
   setProtocol(prot,prot);
   }
-  void setProtocol(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
+  void setProtocol(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
     piprot_=iprot;
     poprot_=oprot;
     iprot_ = iprot.get();
     oprot_ = oprot.get();
   }
  public:
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
     return piprot_;
   }
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
     return poprot_;
   }
   bool checkTrace(const TInfo& tinfo, const std::string& message);
   void send_checkTrace(const TInfo& tinfo, const std::string& message);
   bool recv_checkTrace();
  protected:
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot_;
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot_;
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot_;
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot_;
   ::apache::thrift::protocol::TProtocol* iprot_;
   ::apache::thrift::protocol::TProtocol* oprot_;
 };
 
 class TestServiceProcessor : public ::apache::thrift::TDispatchProcessor {
  protected:
-  boost::shared_ptr<TestServiceIf> iface_;
+  std::shared_ptr<TestServiceIf> iface_;
   virtual bool dispatchCall(::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, const std::string& fname, int32_t seqid, void* callContext);
  private:
   typedef  void (TestServiceProcessor::*ProcessFunction)(int32_t, ::apache::thrift::protocol::TProtocol*, ::apache::thrift::protocol::TProtocol*, void*);
@@ -223,7 +223,7 @@ class TestServiceProcessor : public ::apache::thrift::TDispatchProcessor {
   ProcessMap processMap_;
   void process_checkTrace(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
  public:
-  TestServiceProcessor(boost::shared_ptr<TestServiceIf> iface) :
+  TestServiceProcessor(std::shared_ptr<TestServiceIf> iface) :
     iface_(iface) {
     processMap_["checkTrace"] = &TestServiceProcessor::process_checkTrace;
   }
@@ -233,24 +233,24 @@ class TestServiceProcessor : public ::apache::thrift::TDispatchProcessor {
 
 class TestServiceProcessorFactory : public ::apache::thrift::TProcessorFactory {
  public:
-  TestServiceProcessorFactory(const ::boost::shared_ptr< TestServiceIfFactory >& handlerFactory) :
+  TestServiceProcessorFactory(const ::std::shared_ptr< TestServiceIfFactory >& handlerFactory) :
       handlerFactory_(handlerFactory) {}
 
-  ::boost::shared_ptr< ::apache::thrift::TProcessor > getProcessor(const ::apache::thrift::TConnectionInfo& connInfo);
+  ::std::shared_ptr< ::apache::thrift::TProcessor > getProcessor(const ::apache::thrift::TConnectionInfo& connInfo);
 
  protected:
-  ::boost::shared_ptr< TestServiceIfFactory > handlerFactory_;
+  ::std::shared_ptr< TestServiceIfFactory > handlerFactory_;
 };
 
 class TestServiceMultiface : virtual public TestServiceIf {
  public:
-  TestServiceMultiface(std::vector<boost::shared_ptr<TestServiceIf> >& ifaces) : ifaces_(ifaces) {
+  TestServiceMultiface(std::vector<std::shared_ptr<TestServiceIf> >& ifaces) : ifaces_(ifaces) {
   }
   virtual ~TestServiceMultiface() {}
  protected:
-  std::vector<boost::shared_ptr<TestServiceIf> > ifaces_;
+  std::vector<std::shared_ptr<TestServiceIf> > ifaces_;
   TestServiceMultiface() {}
-  void add(boost::shared_ptr<TestServiceIf> iface) {
+  void add(std::shared_ptr<TestServiceIf> iface) {
     ifaces_.push_back(iface);
   }
  public:

--- a/include/data/extern/thrift/ThriftTest.h
+++ b/include/data/extern/thrift/ThriftTest.h
@@ -32,7 +32,7 @@ class ThriftTestIfFactory {
 
 class ThriftTestIfSingletonFactory : virtual public ThriftTestIfFactory {
  public:
-  ThriftTestIfSingletonFactory(const boost::shared_ptr<ThriftTestIf>& iface) : iface_(iface) {}
+  ThriftTestIfSingletonFactory(const std::shared_ptr<ThriftTestIf>& iface) : iface_(iface) {}
   virtual ~ThriftTestIfSingletonFactory() {}
 
   virtual ThriftTestIf* getHandler(const ::apache::thrift::TConnectionInfo&) {
@@ -41,7 +41,7 @@ class ThriftTestIfSingletonFactory : virtual public ThriftTestIfFactory {
   virtual void releaseHandler(ThriftTestIf* /* handler */) {}
 
  protected:
-  boost::shared_ptr<ThriftTestIf> iface_;
+  std::shared_ptr<ThriftTestIf> iface_;
 };
 
 class ThriftTestNull : virtual public ThriftTestIf {
@@ -395,27 +395,27 @@ class ThriftTest_throwsError_presult {
 
 class ThriftTestClient : virtual public ThriftTestIf {
  public:
-  ThriftTestClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
+  ThriftTestClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
     setProtocol(prot);
   }
-  ThriftTestClient(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
+  ThriftTestClient(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
     setProtocol(iprot,oprot);
   }
  private:
-  void setProtocol(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
+  void setProtocol(std::shared_ptr< ::apache::thrift::protocol::TProtocol> prot) {
   setProtocol(prot,prot);
   }
-  void setProtocol(boost::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, boost::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
+  void setProtocol(std::shared_ptr< ::apache::thrift::protocol::TProtocol> iprot, std::shared_ptr< ::apache::thrift::protocol::TProtocol> oprot) {
     piprot_=iprot;
     poprot_=oprot;
     iprot_ = iprot.get();
     oprot_ = oprot.get();
   }
  public:
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getInputProtocol() {
     return piprot_;
   }
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> getOutputProtocol() {
     return poprot_;
   }
   bool success();
@@ -428,15 +428,15 @@ class ThriftTestClient : virtual public ThriftTestIf {
   void send_throwsError();
   bool recv_throwsError();
  protected:
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot_;
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot_;
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> piprot_;
+  std::shared_ptr< ::apache::thrift::protocol::TProtocol> poprot_;
   ::apache::thrift::protocol::TProtocol* iprot_;
   ::apache::thrift::protocol::TProtocol* oprot_;
 };
 
 class ThriftTestProcessor : public ::apache::thrift::TDispatchProcessor {
  protected:
-  boost::shared_ptr<ThriftTestIf> iface_;
+  std::shared_ptr<ThriftTestIf> iface_;
   virtual bool dispatchCall(::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, const std::string& fname, int32_t seqid, void* callContext);
  private:
   typedef  void (ThriftTestProcessor::*ProcessFunction)(int32_t, ::apache::thrift::protocol::TProtocol*, ::apache::thrift::protocol::TProtocol*, void*);
@@ -446,7 +446,7 @@ class ThriftTestProcessor : public ::apache::thrift::TDispatchProcessor {
   void process_fails(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
   void process_throwsError(int32_t seqid, ::apache::thrift::protocol::TProtocol* iprot, ::apache::thrift::protocol::TProtocol* oprot, void* callContext);
  public:
-  ThriftTestProcessor(boost::shared_ptr<ThriftTestIf> iface) :
+  ThriftTestProcessor(std::shared_ptr<ThriftTestIf> iface) :
     iface_(iface) {
     processMap_["success"] = &ThriftTestProcessor::process_success;
     processMap_["fails"] = &ThriftTestProcessor::process_fails;
@@ -458,24 +458,24 @@ class ThriftTestProcessor : public ::apache::thrift::TDispatchProcessor {
 
 class ThriftTestProcessorFactory : public ::apache::thrift::TProcessorFactory {
  public:
-  ThriftTestProcessorFactory(const ::boost::shared_ptr< ThriftTestIfFactory >& handlerFactory) :
+  ThriftTestProcessorFactory(const ::std::shared_ptr< ThriftTestIfFactory >& handlerFactory) :
       handlerFactory_(handlerFactory) {}
 
-  ::boost::shared_ptr< ::apache::thrift::TProcessor > getProcessor(const ::apache::thrift::TConnectionInfo& connInfo);
+  ::std::shared_ptr< ::apache::thrift::TProcessor > getProcessor(const ::apache::thrift::TConnectionInfo& connInfo);
 
  protected:
-  ::boost::shared_ptr< ThriftTestIfFactory > handlerFactory_;
+  ::std::shared_ptr< ThriftTestIfFactory > handlerFactory_;
 };
 
 class ThriftTestMultiface : virtual public ThriftTestIf {
  public:
-  ThriftTestMultiface(std::vector<boost::shared_ptr<ThriftTestIf> >& ifaces) : ifaces_(ifaces) {
+  ThriftTestMultiface(std::vector<std::shared_ptr<ThriftTestIf> >& ifaces) : ifaces_(ifaces) {
   }
   virtual ~ThriftTestMultiface() {}
  protected:
-  std::vector<boost::shared_ptr<ThriftTestIf> > ifaces_;
+  std::vector<std::shared_ptr<ThriftTestIf> > ifaces_;
   ThriftTestMultiface() {}
-  void add(boost::shared_ptr<ThriftTestIf> iface) {
+  void add(std::shared_ptr<ThriftTestIf> iface) {
     ifaces_.push_back(iface);
   }
  public:

--- a/include/data/extern/thrift/client_types.h
+++ b/include/data/extern/thrift/client_types.h
@@ -14,7 +14,6 @@
 #include <thrift/protocol/TProtocol.h>
 #include <thrift/transport/TTransport.h>
 
-#include <thrift/cxxfunctional.h>
 #include "security_types.h"
 #include "trace_types.h"
 

--- a/include/data/extern/thrift/data_types.h
+++ b/include/data/extern/thrift/data_types.h
@@ -14,7 +14,6 @@
 #include <thrift/protocol/TProtocol.h>
 #include <thrift/transport/TTransport.h>
 
-#include <thrift/cxxfunctional.h>
 #include "security_types.h"
 #include "client_types.h"
 

--- a/include/data/extern/thrift/gc_types.h
+++ b/include/data/extern/thrift/gc_types.h
@@ -14,7 +14,6 @@
 #include <thrift/protocol/TProtocol.h>
 #include <thrift/transport/TTransport.h>
 
-#include <thrift/cxxfunctional.h>
 #include "security_types.h"
 #include "trace_types.h"
 #include "client_types.h"

--- a/include/data/extern/thrift/master_types.h
+++ b/include/data/extern/thrift/master_types.h
@@ -14,7 +14,6 @@
 #include <thrift/protocol/TProtocol.h>
 #include <thrift/transport/TTransport.h>
 
-#include <thrift/cxxfunctional.h>
 #include "data_types.h"
 #include "security_types.h"
 #include "client_types.h"

--- a/include/data/extern/thrift/security_types.h
+++ b/include/data/extern/thrift/security_types.h
@@ -14,8 +14,6 @@
 #include <thrift/protocol/TProtocol.h>
 #include <thrift/transport/TTransport.h>
 
-#include <thrift/cxxfunctional.h>
-
 
 namespace org { namespace apache { namespace accumulo { namespace core { namespace security { namespace thrift {
 

--- a/include/data/extern/thrift/tabletserver_types.h
+++ b/include/data/extern/thrift/tabletserver_types.h
@@ -13,8 +13,6 @@
 #include <thrift/TApplicationException.h>
 #include <thrift/protocol/TProtocol.h>
 #include <thrift/transport/TTransport.h>
-
-#include <thrift/cxxfunctional.h>
 #include "data_types.h"
 #include "security_types.h"
 #include "client_types.h"

--- a/include/data/extern/thrift/trace_types.h
+++ b/include/data/extern/thrift/trace_types.h
@@ -14,8 +14,6 @@
 #include <thrift/protocol/TProtocol.h>
 #include <thrift/transport/TTransport.h>
 
-#include <thrift/cxxfunctional.h>
-
 
 namespace org { namespace apache { namespace accumulo { namespace core { namespace trace { namespace thrift {
 

--- a/include/data/extern/thrift/tracer_types.h
+++ b/include/data/extern/thrift/tracer_types.h
@@ -14,7 +14,6 @@
 #include <thrift/protocol/TProtocol.h>
 #include <thrift/transport/TTransport.h>
 
-#include <thrift/cxxfunctional.h>
 
 
 namespace org { namespace apache { namespace accumulo { namespace tracer { namespace thrift {

--- a/include/interconnect/accumulo/AccumuloMasterFacade.h
+++ b/include/interconnect/accumulo/AccumuloMasterFacade.h
@@ -46,9 +46,9 @@ class AccumuloMasterFacade {
   std::function<std::shared_ptr<apache::thrift::transport::TTransport>()> createTransport;
   std::function<void()> createMasterTransport;
 
-  void v1_createMasterClient(boost::shared_ptr<apache::thrift::transport::TTransport> underlyingTransport) {
+  void v1_createMasterClient(std::shared_ptr<apache::thrift::transport::TTransport> underlyingTransport) {
     auto protocolPtr = std::make_shared<apache::thrift::protocol::TCompactProtocol>(underlyingTransport);
-    //boost::shared_ptr<apache::thrift::protocol::TProtocol> protocolPtr(new apache::thrift::protocol::TCompactProtocol(underlyingTransport));
+    //std::shared_ptr<apache::thrift::protocol::TProtocol> protocolPtr(new apache::thrift::protocol::TCompactProtocol(underlyingTransport));
     //if (NULL != masterClient) {
 
     //      delete masterClient;
@@ -111,8 +111,8 @@ class AccumuloMasterFacade {
     tableArgs.push_back(table);
     tableArgs.push_back(startrow);
     tableArgs.push_back(endrow);
-    boost::shared_ptr<apache::thrift::transport::TMemoryBuffer> strBuffer(new apache::thrift::transport::TMemoryBuffer());
-    boost::shared_ptr<apache::thrift::protocol::TBinaryProtocol> binaryProtcol(new apache::thrift::protocol::TBinaryProtocol(strBuffer));
+    std::shared_ptr<apache::thrift::transport::TMemoryBuffer> strBuffer(new apache::thrift::transport::TMemoryBuffer());
+    std::shared_ptr<apache::thrift::protocol::TBinaryProtocol> binaryProtcol(new apache::thrift::protocol::TBinaryProtocol(strBuffer));
     org::apache::accumulo::core::tabletserver::thrift::IteratorConfig config;
     config.write(binaryProtcol.get());
 
@@ -138,14 +138,13 @@ class AccumuloMasterFacade {
     tableArgs.push_back(table);
     tableArgs.push_back(startrow);
     tableArgs.push_back(endrow);
-    boost::shared_ptr<apache::thrift::transport::TMemoryBuffer> strBuffer(new apache::thrift::transport::TMemoryBuffer());
-    boost::shared_ptr<apache::thrift::protocol::TBinaryProtocol> binaryProtcol(new apache::thrift::protocol::TBinaryProtocol(strBuffer));
+    std::shared_ptr<apache::thrift::transport::TMemoryBuffer> strBuffer(new apache::thrift::transport::TMemoryBuffer());
+    std::shared_ptr<apache::thrift::protocol::TBinaryProtocol> binaryProtcol(new apache::thrift::protocol::TBinaryProtocol(strBuffer));
     org::apache::accumulo::core::tabletserver::thrift::IteratorConfig config;
     org::apache::accumulo::core::tabletserver::thrift::TIteratorSetting setting;
     setting.name = "vers";
     setting.priority = 10;
     setting.iteratorClass = "org.apache.accumulo.core.iterators.user.VersioningIterator";
-    setting.properties.insert(std::make_pair<std::string, std::string>("maxVersions", "1"));
 
     //config.iterators.push_back(setting);
 
@@ -349,7 +348,7 @@ class AccumuloMasterFacade {
     accumuloVersion = ACCUMULO_ONE;
   }
 
-  void createMasterClient(boost::shared_ptr<apache::thrift::transport::TTransport> underlyingTransport) {
+  void createMasterClient(std::shared_ptr<apache::thrift::transport::TTransport> underlyingTransport) {
     switch (accumuloVersion) {
       case ACCUMULO_ONE:
         v1_createMasterClient(underlyingTransport);

--- a/include/interconnect/accumulo/AccumuloServerFacade.h
+++ b/include/interconnect/accumulo/AccumuloServerFacade.h
@@ -109,7 +109,7 @@ class AccumuloServerFacade {
 
   void close();
 
-  void initialize(boost::shared_ptr<apache::thrift::protocol::TProtocol> protocolPtr);
+  void initialize(std::shared_ptr<apache::thrift::protocol::TProtocol> protocolPtr);
 
   std::map<std::string, std::string> getNamespaceConfiguration(cclient::data::security::AuthInfo *auth, const std::string &nameSpaceName);
 

--- a/include/interconnect/transport/BaseTransport.h
+++ b/include/interconnect/transport/BaseTransport.h
@@ -56,7 +56,7 @@ namespace interconnect {
 
 class ThriftTransporter : virtual public ServerTransport<apache::thrift::transport::TTransport, cclient::data::KeyExtent, cclient::data::Range*, cclient::data::Mutation*> {
  protected:
-  boost::shared_ptr<apache::thrift::transport::TTransport> underlyingTransport;
+  std::shared_ptr<apache::thrift::transport::TTransport> underlyingTransport;
 
   AccumuloServerFacade server;
 

--- a/src/data/extern/thrift/ClientService.cpp
+++ b/src/data/extern/thrift/ClientService.cpp
@@ -11138,10 +11138,10 @@ void ClientServiceProcessor::process_checkNamespaceClass(int32_t seqid, ::apache
   }
 }
 
-::boost::shared_ptr< ::apache::thrift::TProcessor > ClientServiceProcessorFactory::getProcessor(const ::apache::thrift::TConnectionInfo& connInfo) {
+::std::shared_ptr< ::apache::thrift::TProcessor > ClientServiceProcessorFactory::getProcessor(const ::apache::thrift::TConnectionInfo& connInfo) {
   ::apache::thrift::ReleaseHandler< ClientServiceIfFactory > cleanup(handlerFactory_);
-  ::boost::shared_ptr< ClientServiceIf > handler(handlerFactory_->getHandler(connInfo), cleanup);
-  ::boost::shared_ptr< ::apache::thrift::TProcessor > processor(new ClientServiceProcessor(handler));
+  ::std::shared_ptr< ClientServiceIf > handler(handlerFactory_->getHandler(connInfo), cleanup);
+  ::std::shared_ptr< ::apache::thrift::TProcessor > processor(new ClientServiceProcessor(handler));
   return processor;
 }
 

--- a/src/data/extern/thrift/FateService.cpp
+++ b/src/data/extern/thrift/FateService.cpp
@@ -1577,10 +1577,10 @@ void FateServiceProcessor::process_finishFateOperation(int32_t seqid, ::apache::
   }
 }
 
-::boost::shared_ptr< ::apache::thrift::TProcessor > FateServiceProcessorFactory::getProcessor(const ::apache::thrift::TConnectionInfo& connInfo) {
+::std::shared_ptr< ::apache::thrift::TProcessor > FateServiceProcessorFactory::getProcessor(const ::apache::thrift::TConnectionInfo& connInfo) {
   ::apache::thrift::ReleaseHandler< FateServiceIfFactory > cleanup(handlerFactory_);
-  ::boost::shared_ptr< FateServiceIf > handler(handlerFactory_->getHandler(connInfo), cleanup);
-  ::boost::shared_ptr< ::apache::thrift::TProcessor > processor(new FateServiceProcessor(handler));
+  ::std::shared_ptr< FateServiceIf > handler(handlerFactory_->getHandler(connInfo), cleanup);
+  ::std::shared_ptr< ::apache::thrift::TProcessor > processor(new FateServiceProcessor(handler));
   return processor;
 }
 

--- a/src/data/extern/thrift/MasterClientService.cpp
+++ b/src/data/extern/thrift/MasterClientService.cpp
@@ -6176,10 +6176,10 @@ void MasterClientServiceProcessor::process_drainReplicationTable(int32_t seqid, 
   }
 }
 
-::boost::shared_ptr< ::apache::thrift::TProcessor > MasterClientServiceProcessorFactory::getProcessor(const ::apache::thrift::TConnectionInfo& connInfo) {
+::std::shared_ptr< ::apache::thrift::TProcessor > MasterClientServiceProcessorFactory::getProcessor(const ::apache::thrift::TConnectionInfo& connInfo) {
   ::apache::thrift::ReleaseHandler< MasterClientServiceIfFactory > cleanup(handlerFactory_);
-  ::boost::shared_ptr< MasterClientServiceIf > handler(handlerFactory_->getHandler(connInfo), cleanup);
-  ::boost::shared_ptr< ::apache::thrift::TProcessor > processor(new MasterClientServiceProcessor(handler));
+  ::std::shared_ptr< MasterClientServiceIf > handler(handlerFactory_->getHandler(connInfo), cleanup);
+  ::std::shared_ptr< ::apache::thrift::TProcessor > processor(new MasterClientServiceProcessor(handler));
   return processor;
 }
 

--- a/src/data/extern/thrift/SpanReceiver.cpp
+++ b/src/data/extern/thrift/SpanReceiver.cpp
@@ -162,10 +162,10 @@ void SpanReceiverProcessor::process_span(int32_t, ::apache::thrift::protocol::TP
   return;
 }
 
-::boost::shared_ptr< ::apache::thrift::TProcessor > SpanReceiverProcessorFactory::getProcessor(const ::apache::thrift::TConnectionInfo& connInfo) {
+::std::shared_ptr< ::apache::thrift::TProcessor > SpanReceiverProcessorFactory::getProcessor(const ::apache::thrift::TConnectionInfo& connInfo) {
   ::apache::thrift::ReleaseHandler< SpanReceiverIfFactory > cleanup(handlerFactory_);
-  ::boost::shared_ptr< SpanReceiverIf > handler(handlerFactory_->getHandler(connInfo), cleanup);
-  ::boost::shared_ptr< ::apache::thrift::TProcessor > processor(new SpanReceiverProcessor(handler));
+  ::std::shared_ptr< SpanReceiverIf > handler(handlerFactory_->getHandler(connInfo), cleanup);
+  ::std::shared_ptr< ::apache::thrift::TProcessor > processor(new SpanReceiverProcessor(handler));
   return processor;
 }
 

--- a/src/data/extern/thrift/TabletClientService.cpp
+++ b/src/data/extern/thrift/TabletClientService.cpp
@@ -10218,10 +10218,10 @@ void TabletClientServiceProcessor::process_getActiveLogs(int32_t seqid, ::apache
   }
 }
 
-::boost::shared_ptr< ::apache::thrift::TProcessor > TabletClientServiceProcessorFactory::getProcessor(const ::apache::thrift::TConnectionInfo& connInfo) {
+::std::shared_ptr< ::apache::thrift::TProcessor > TabletClientServiceProcessorFactory::getProcessor(const ::apache::thrift::TConnectionInfo& connInfo) {
   ::apache::thrift::ReleaseHandler< TabletClientServiceIfFactory > cleanup(handlerFactory_);
-  ::boost::shared_ptr< TabletClientServiceIf > handler(handlerFactory_->getHandler(connInfo), cleanup);
-  ::boost::shared_ptr< ::apache::thrift::TProcessor > processor(new TabletClientServiceProcessor(handler));
+  ::std::shared_ptr< TabletClientServiceIf > handler(handlerFactory_->getHandler(connInfo), cleanup);
+  ::std::shared_ptr< ::apache::thrift::TProcessor > processor(new TabletClientServiceProcessor(handler));
   return processor;
 }
 

--- a/src/interconnect/accumulo/AccumuloServerFacade.cpp
+++ b/src/interconnect/accumulo/AccumuloServerFacade.cpp
@@ -148,7 +148,7 @@ void AccumuloServerFacade::v1_close() {
   }
 }
 
-void AccumuloServerFacade::initialize(boost::shared_ptr<apache::thrift::protocol::TProtocol> protocolPtr) {
+void AccumuloServerFacade::initialize(std::shared_ptr<apache::thrift::protocol::TProtocol> protocolPtr) {
   client = std::make_unique<org::apache::accumulo::core::client::impl::thrift::ClientServiceClient>(protocolPtr);
   tserverClient = std::make_unique<org::apache::accumulo::core::tabletserver::thrift::TabletClientServiceClient>(protocolPtr);
   accumuloVersion = ACCUMULO_ONE;

--- a/src/interconnect/transport/accumulo/BaseTransport.cpp
+++ b/src/interconnect/transport/accumulo/BaseTransport.cpp
@@ -56,7 +56,7 @@ void ThriftTransporter::closeAndCreateClient() {
 
 void ThriftTransporter::createClientService() {
 
-  boost::shared_ptr<apache::thrift::protocol::TProtocol> protocolPtr(new apache::thrift::protocol::TCompactProtocol(underlyingTransport));
+  std::shared_ptr<apache::thrift::protocol::TProtocol> protocolPtr(new apache::thrift::protocol::TCompactProtocol(underlyingTransport));
 
   server.close();
 
@@ -68,9 +68,9 @@ void ThriftTransporter::newTransporter(const std::shared_ptr<ServerConnection> &
 
   clonedConnection = conn;
 
-  boost::shared_ptr<apache::thrift::transport::TSocket> serverTransport(new apache::thrift::transport::TSocket(conn->getHost(), conn->getPort()));
+  std::shared_ptr<apache::thrift::transport::TSocket> serverTransport(new apache::thrift::transport::TSocket(conn->getHost(), conn->getPort()));
 
-  boost::shared_ptr<apache::thrift::transport::TTransport> transporty(new apache::thrift::transport::TFramedTransport(serverTransport));
+  std::shared_ptr<apache::thrift::transport::TTransport> transporty(new apache::thrift::transport::TFramedTransport(serverTransport));
 
   try {
     std::cout << "attempting to connect to ! to " << conn->getHost() << " and " << conn->getPort() << std::endl;


### PR DESCRIPTION
@mjwall feel free to take a look. this upgrades thrift usage to 0.12.0 so we should be able to autodetect the cluster version and scan/integrate with 1.x and 2.x clusters very soon. 